### PR TITLE
Params improvements

### DIFF
--- a/config.go
+++ b/config.go
@@ -7,7 +7,7 @@ import (
 	"os/user"
 	"path"
 
-	"gopkg.in/yaml.v1"
+	"gopkg.in/yaml.v2"
 
 	"github.com/phrase/phraseapp-go/phraseapp"
 )

--- a/main_test.go
+++ b/main_test.go
@@ -19,6 +19,7 @@ phraseapp:
         file: ./locales/file.yml
         params:
           file_format: strings
+          locale_id: en
 `
 	config := &PullConfig{}
 	err := yaml.Unmarshal([]byte(pullConfig), &config)
@@ -27,8 +28,14 @@ phraseapp:
 	}
 
 	targetParams := config.Phraseapp.Pull.Targets[0].Params
-	if targetParams.FileFormat != "strings" {
-		t.Errorf("Expected FileFormat of first target to be %s and not %s", "strings", targetParams.FileFormat)
+	if targetParams.FileFormat == nil {
+		t.Errorf("FileFormat not set")
+	} else if *targetParams.FileFormat != "strings" {
+		t.Errorf("Expected FileFormat of first target to be %s and not %s", "strings", *targetParams.FileFormat)
+	}
+
+	if targetParams.LocaleID  != "en" {
+		t.Errorf("Expected LocaleID of first target to be %s and not %s", "en", targetParams.LocaleID)
 	}
 }
 
@@ -53,6 +60,8 @@ phraseapp:
 		t.Errorf("Expected FileFormat of first target to be %s and not %s", "strings", sourceParams.FileFormat)
 	}
 }
+
+
 
 func getBaseLocales() []*phraseapp.Locale {
 	return []*phraseapp.Locale{

--- a/main_test.go
+++ b/main_test.go
@@ -4,9 +4,10 @@ import (
 	"testing"
 
 	"fmt"
-	"github.com/phrase/phraseapp-go/phraseapp"
-	"gopkg.in/yaml.v1"
 	"sort"
+
+	"github.com/phrase/phraseapp-go/phraseapp"
+	"gopkg.in/yaml.v2"
 )
 
 func TestPullConfig(t *testing.T) {

--- a/main_test.go
+++ b/main_test.go
@@ -48,7 +48,7 @@ phraseapp:
 	}
 
 	sourceParams := config.Phraseapp.Push.Sources[0].Params
-	if sourceParams.FileFormat != "strings" {
+	if sourceParams.FileFormat == nil || *sourceParams.FileFormat != "strings" {
 		t.Errorf("Expected FileFormat of first target to be %s and not %s", "strings", sourceParams.FileFormat)
 	}
 }

--- a/pull_test.go
+++ b/pull_test.go
@@ -13,16 +13,7 @@ func getBaseTarget() *Target {
 		ProjectID:   "project-id",
 		AccessToken: "access-token",
 		FileFormat:  "yml",
-		Params: &PullParams{
-			FileFormat:                 "",
-			LocaleID:                   "",
-			Encoding:                   "",
-			ConvertEmoji:               false,
-			IncludeEmptyTranslations:   false,
-			KeepNotranslateTags:        false,
-			SkipUnverifiedTranslations: false,
-			Tag: "",
-		},
+		Params: new(PullParams),
 		RemoteLocales: getBaseLocales(),
 	}
 	return target

--- a/push.go
+++ b/push.go
@@ -49,22 +49,12 @@ type Source struct {
 	ProjectID     string      `yaml:"project_id,omitempty"`
 	AccessToken   string      `yaml:"access_token,omitempty"`
 	FileFormat    string      `yaml:"file_format,omitempty"`
-	Params        *PushParams `yaml:"params"`
+	Params        *phraseapp.UploadParams `yaml:"params"`
+
 	RemoteLocales []*phraseapp.Locale
 	Extension     string
 }
 
-type PushParams struct {
-	FileFormat   string `yaml:"file_format,omitempty"`
-	FileEncoding   string `yaml:"file_encoding,omitempty"`
-	LocaleID     string `yaml:"locale_id,omitempty"`
-	ConvertEmoji *bool  `yaml:"convert_emoji,omitempty"`
-	//FormatOptions      *map[string]interface{} `yaml:"format_options,omitempty"`
-	SkipUnverification *bool   `yaml:"skip_unverification,omitempty"`
-	SkipUploadTags     *bool   `yaml:"skip_upload_tags,omitempty"`
-	Tags               *string `yaml:"tags,omitempty"`
-	UpdateTranslations *bool   `yaml:"update_translations,omitempty"`
-}
 
 var separator = string(os.PathSeparator)
 
@@ -178,17 +168,26 @@ func (source *Source) replacePlaceholderInParams(localeFile *LocaleFile) string 
 }
 
 func (source *Source) uploadFile(client *phraseapp.Client, localeFile *LocaleFile) error {
-	uploadParams, err := source.setUploadParams(localeFile)
-	if err != nil {
-		return err
-	}
-
 	if Debug {
 		fmt.Fprintln(os.Stdout, "Source file pattern:", source.File)
 		fmt.Fprintln(os.Stdout, "Actual file location:", localeFile.Path)
 	}
 
-	aUpload, err := client.UploadCreate(source.ProjectID, uploadParams)
+	params := new(phraseapp.UploadParams)
+	*params = *source.Params
+
+	params.File = &localeFile.Path
+
+	if params.LocaleID == nil {
+		switch {
+		case localeFile.ID != "":
+			params.LocaleID = &localeFile.ID
+		case localeFile.RFC != "":
+			params.LocaleID = &localeFile.RFC
+		}
+	}
+
+	aUpload, err := client.UploadCreate(source.ProjectID, params)
 	if err != nil {
 		return err
 	}
@@ -420,8 +419,17 @@ func SourcesFromConfig(cmd *PushCommand) (Sources, error) {
 		if source.AccessToken == "" {
 			source.AccessToken = token
 		}
-		if source.FileFormat == "" {
-			source.FileFormat = fileFormat
+		if source.Params == nil {
+			source.Params = new(phraseapp.UploadParams)
+		}
+
+		if source.Params.FileFormat == nil {
+			switch {
+			case source.FileFormat != "":
+				source.Params.FileFormat = &source.FileFormat
+			case fileFormat != "":
+				source.Params.FileFormat = &fileFormat
+			}
 		}
 		validSources = append(validSources, source)
 	}
@@ -436,79 +444,10 @@ func SourcesFromConfig(cmd *PushCommand) (Sources, error) {
 }
 
 func (source *Source) GetLocaleID() string {
-	if source.Params != nil {
-		return source.Params.LocaleID
+	if source.Params != nil && source.Params.LocaleID != nil {
+		return *source.Params.LocaleID
 	}
 	return ""
-}
-
-func (source *Source) setUploadParams(localeFile *LocaleFile) (*phraseapp.UploadParams, error) {
-	uploadParams := new(phraseapp.UploadParams)
-	uploadParams.File = &localeFile.Path
-	uploadParams.FileFormat = &source.FileFormat
-
-	if localeFile.ID != "" {
-		uploadParams.LocaleID = &localeFile.ID
-	} else if localeFile.RFC != "" {
-		uploadParams.LocaleID = &localeFile.RFC
-	}
-
-	if localeFile.Tag != "" {
-		uploadParams.Tags = &localeFile.Tag
-	}
-
-	if source.Params == nil {
-		return uploadParams, nil
-	}
-
-	params := source.Params
-
-	localeID := params.LocaleID
-	if localeID != "" {
-		uploadParams.LocaleID = &localeID
-	}
-
-	format := params.FileFormat
-	if format != "" {
-		uploadParams.FileFormat = &format
-	}
-
-	fileEncoding := params.FileEncoding
-	if fileEncoding != "" {
-		uploadParams.FileEncoding = &fileEncoding
-	}
-
-	convertEmoji := params.ConvertEmoji
-	if convertEmoji != nil {
-		uploadParams.ConvertEmoji = convertEmoji
-	}
-
-	//	formatOptions := params.FormatOptions
-	//	if formatOptions != nil {
-	//		uploadParams.FormatOptions = formatOptions
-	//	}
-
-	skipUnverification := params.SkipUnverification
-	if skipUnverification != nil {
-		uploadParams.SkipUnverification = skipUnverification
-	}
-
-	skipUploadTags := params.SkipUploadTags
-	if skipUploadTags != nil {
-		uploadParams.SkipUploadTags = skipUploadTags
-	}
-
-	tags := params.Tags
-	if tags != nil && uploadParams.Tags == nil {
-		uploadParams.Tags = tags
-	}
-
-	updateTranslations := params.UpdateTranslations
-	if updateTranslations != nil {
-		uploadParams.UpdateTranslations = updateTranslations
-	}
-
-	return uploadParams, nil
 }
 
 // Print out

--- a/push_test.go
+++ b/push_test.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"github.com/phrase/phraseapp-go/phraseapp"
 )
 
 func getBaseSource() *Source {
@@ -14,15 +15,7 @@ func getBaseSource() *Source {
 		AccessToken: "access-token",
 		FileFormat:  "yml",
 		Extension:   "",
-		Params: &PushParams{
-			FileFormat:         "",
-			LocaleID:           "",
-			ConvertEmoji:       nil,
-			SkipUnverification: nil,
-			SkipUploadTags:     nil,
-			Tags:               nil,
-			UpdateTranslations: nil,
-		},
+		Params: new(phraseapp.UploadParams),
 		RemoteLocales: getBaseLocales(),
 	}
 	source.Extension = filepath.Ext(source.File)
@@ -140,7 +133,8 @@ func TestSourceLocaleFilesTwo(t *testing.T) {
 func TestReplacePlaceholderInParams(t *testing.T) {
 	fmt.Println("Push#Source#ReplacePlaceholderInParams")
 	source := getBaseSource()
-	source.Params.LocaleID = "<locale_code>"
+	lid := "<locale_code>"
+	source.Params.LocaleID = &lid
 	localeFile := &LocaleFile{
 		Name: "en",
 		RFC:  "en",

--- a/wizard.go
+++ b/wizard.go
@@ -13,7 +13,7 @@ import (
 	"sync"
 	"time"
 
-	"gopkg.in/yaml.v1"
+	"gopkg.in/yaml.v2"
 
 	"github.com/daviddengcn/go-colortext"
 	"github.com/phrase/phraseapp-go/phraseapp"


### PR DESCRIPTION
This reuses existing data structures from the phraseapp-go library. This reduces friction when adding features (support in push and pull must not be added explicitly).