### PR TITLE
Windows issues

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -56,8 +56,10 @@ phraseapp:
 	}
 
 	sourceParams := config.Phraseapp.Push.Sources[0].Params
-	if sourceParams.FileFormat == nil || *sourceParams.FileFormat != "strings" {
-		t.Errorf("Expected FileFormat of first target to be %s and not %s", "strings", sourceParams.FileFormat)
+	if sourceParams.FileFormat == nil {
+		t.Errorf("Expected FileFormat of first target to be %s, not nil", "strings")
+	} else if *sourceParams.FileFormat != "strings" {
+		t.Errorf("Expected FileFormat of first target to be %s, not %s", "strings", *sourceParams.FileFormat)
 	}
 }
 

--- a/pull.go
+++ b/pull.go
@@ -148,7 +148,9 @@ func (target *Target) Pull(client *phraseapp.Client) error {
 
 func (target *Target) DownloadAndWriteToFile(client *phraseapp.Client, localeFile *LocaleFile) error {
 	downloadParams := new(phraseapp.LocaleDownloadParams)
-	*downloadParams = target.Params.LocaleDownloadParams
+	if target.Params != nil {
+		*downloadParams = target.Params.LocaleDownloadParams
+	}
 
 	if downloadParams.FileFormat == nil {
 		downloadParams.FileFormat = &localeFile.FileFormat

--- a/pull.go
+++ b/pull.go
@@ -79,7 +79,7 @@ func (target *Target) CheckPreconditions() error {
 
 	if strings.Count(target.File, "*") > 0 {
 		return fmt.Errorf(
-			"File pattern for 'pull' cannot include any 'stars' *. Please specify direct and valid paths with file name!",
+			"File pattern for 'pull' cannot include any 'stars' *. Please specify direct and valid paths with file name!\n"+
 			"http://docs.phraseapp.com/developers/cli/configuration/#targets",
 		)
 	}

--- a/pull_test.go
+++ b/pull_test.go
@@ -102,7 +102,7 @@ func TestTargetLocaleFiles(t *testing.T) {
 			t.Errorf(err.Error())
 		}
 	} else {
-		t.Errorf("LocaleFiles should contain %s and not %s", expectedFiles, localeFiles)
+		t.Errorf("LocaleFiles should contain %v and not %v", expectedFiles, localeFiles)
 	}
 }
 

--- a/push.go
+++ b/push.go
@@ -215,15 +215,7 @@ func (source *Source) SystemFiles() ([]string, error) {
 }
 
 func (source *Source) glob() ([]string, error) {
-	withoutPlaceholder := placeholderRegexp.ReplaceAllString(source.File, "*")
-	tokens := splitPathToTokens(withoutPlaceholder)
-
-	fileHead := tokens[len(tokens)-1]
-	if strings.HasPrefix(fileHead, ".") {
-		tokens[len(tokens)-1] = "*" + fileHead
-	}
-	pattern := strings.Join(tokens, separator)
-
+	pattern := placeholderRegexp.ReplaceAllString(source.File, "*")
 	files, err := filepath.Glob(pattern)
 	if err != nil {
 		return nil, err

--- a/push.go
+++ b/push.go
@@ -10,6 +10,7 @@ import (
 	"gopkg.in/yaml.v2"
 
 	"github.com/phrase/phraseapp-go/phraseapp"
+	"unicode/utf8"
 )
 
 type PushCommand struct {
@@ -331,9 +332,39 @@ func (source *Source) getRemoteLocaleForLocaleFile(localeFile *LocaleFile) *phra
 	return nil
 }
 
+func splitString(s string, set string) ([]string) {
+	if len(set) == 1 {
+		return strings.Split(s, set)
+	}
+
+	slist := []string{}
+	charSet := map[rune]bool{}
+
+	for _, r := range set {
+		charSet[r] = true
+	}
+
+	start := 0
+	for i, r := range s {
+		if _, found := charSet[r]; found {
+			slist = append(slist, s[start:i])
+			start = i+utf8.RuneLen(r)
+		}
+	}
+	if start < len(s) {
+		slist = append(slist, s[start:])
+	}
+
+	return slist
+}
+
 func splitPathToTokens(s string) []string {
 	tokens := []string{}
-	for _, token := range strings.Split(s, separator) {
+	splitSet := separator
+	if separator == "\\" {
+		splitSet = "\\/"
+	}
+	for _, token := range splitString(s, splitSet) {
 		if token == "." || token == "" {
 			continue
 		}

--- a/push.go
+++ b/push.go
@@ -290,10 +290,10 @@ func (source *Source) LocaleFiles() (LocaleFiles, error) {
 		}
 
 		if Debug {
-			fmt.Println(fmt.Sprintf(
-				"RFC:'%s', Name:'%s', Tag;'%s', Pattern:'%s'",
-				localeFile.RFC, localeFile.Name, localeFile.Tag,
-			))
+			fmt.Printf(
+				"RFC:%q, Name:%q, ID:%q, Tag:%q\n",
+				localeFile.RFC, localeFile.Name, localeFile.ID, localeFile.Tag,
+			)
 		}
 
 		localeFiles = append(localeFiles, localeFile)

--- a/push_test.go
+++ b/push_test.go
@@ -443,3 +443,25 @@ func TestReducerPatterns(t *testing.T) {
 	}
 	fmt.Println(strings.Repeat("-", 10))
 }
+
+func TestSplitString(t *testing.T) {
+	tt := []struct {
+		str string
+		cut string
+		exp []string
+	}{
+		{"a/b/c/d", "/\\", []string{"a", "b", "c", "d"}},
+		{"a/b\\c/d", "/\\", []string{"a", "b", "c", "d"}},
+		{"/a/b/c/d/", "/\\", []string{"", "a", "b", "c", "d"}},
+		{"a/b/日\\本/語/d", "/\\", []string{"a", "b", "日", "本", "語", "d"}},
+		{"a/b/日\\c本c/語/d", "/\\本", []string{"a", "b", "日", "c", "c", "語", "d"}},
+	}
+
+	for i := range tt {
+		got := splitString(tt[i].str, tt[i].cut)
+		if len(got) != len(tt[i].exp) {
+			t.Errorf("expected %d elements for %q, got %d", len(tt[i].exp), tt[i].str, len(got))
+		}
+	}
+
+}

--- a/push_test.go
+++ b/push_test.go
@@ -95,7 +95,7 @@ func TestSourceLocaleFilesOne(t *testing.T) {
 			t.Errorf(err.Error())
 		}
 	} else {
-		t.Errorf(".LocaleFiles should contain %s and not %s", expectedFiles, localeFiles)
+		t.Errorf("LocaleFiles should contain %v and not %v", expectedFiles, localeFiles)
 	}
 }
 
@@ -124,7 +124,7 @@ func TestSourceLocaleFilesTwo(t *testing.T) {
 			t.Errorf(err.Error())
 		}
 	} else {
-		t.Errorf("LocaleFiles should contain %s and not %s", expectedFiles, localeFiles)
+		t.Errorf("LocaleFiles should contain %v and not %v", expectedFiles, localeFiles)
 	}
 }
 

--- a/shared.go
+++ b/shared.go
@@ -159,7 +159,7 @@ func TakeWhile(seq []string, predicate func(string) bool) []string {
 
 func Exists(absPath string) error {
 	if _, err := os.Stat(absPath); os.IsNotExist(err) {
-		return fmt.Errorf("no such file or directory:", absPath)
+		return fmt.Errorf("no such file or directory: %s", absPath)
 	}
 	return nil
 }

--- a/shared.go
+++ b/shared.go
@@ -178,7 +178,6 @@ func ReportError(name string, message string) {
 
 	body, err := json.Marshal(bs)
 	if err != nil {
-		fmt.Errorf("Error: %s", err)
 		return
 	}
 
@@ -188,7 +187,7 @@ func ReportError(name string, message string) {
 	client := http.Client{}
 	resp, err := client.Do(req)
 	if err != nil {
-		fmt.Errorf("Error: %s", err)
+		return
 	}
 	resp.Body.Close()
 


### PR DESCRIPTION
Fix some issues that I encountered when testing on Windows:

* source pattern might contain `/` and not only the default host system separator.
* error reporting failed with a nil pointer exception (missing return)
* removed undocumented behavior (in source pattern `foo/bar/*.yml` the final `*` could be omitted)