### PR TITLE
Better feedback in push command

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -2,9 +2,6 @@
 	"ImportPath": "github.com/phrase/phraseapp-client",
 	"GoVersion": "go1.7",
 	"GodepVersion": "v75",
-	"Packages": [
-		"./..."
-	],
 	"Deps": [
 		{
 			"ImportPath": "github.com/bgentry/speakeasy",
@@ -25,6 +22,10 @@
 		{
 			"ImportPath": "github.com/dynport/dgtk/version",
 			"Rev": "31c7c12b1d6eb1823d775041589f8e4fff12549b"
+		},
+		{
+			"ImportPath": "github.com/jpillora/backoff",
+			"Rev": "a6f64285fd4072883335339357436b78d62c96a4"
 		},
 		{
 			"ImportPath": "github.com/phrase/phraseapp-go/phraseapp",

--- a/push_source.go
+++ b/push_source.go
@@ -156,7 +156,7 @@ func (sources Sources) ProjectIds() []string {
 	}
 	return projectIds
 }
-func (source *Source) uploadFile(client *phraseapp.Client, localeFile *LocaleFile) error {
+func (source *Source) uploadFile(client *phraseapp.Client, localeFile *LocaleFile) (*phraseapp.Upload, error) {
 	if Debug {
 		fmt.Fprintln(os.Stdout, "Source file pattern:", source.File)
 		fmt.Fprintln(os.Stdout, "Actual file location:", localeFile.Path)
@@ -185,8 +185,7 @@ func (source *Source) uploadFile(client *phraseapp.Client, localeFile *LocaleFil
 		params.Tags = &v
 	}
 
-	_, err := client.UploadCreate(source.ProjectID, params)
-	return err
+	return client.UploadCreate(source.ProjectID, params)
 }
 
 func (source *Source) createLocale(client *phraseapp.Client, localeFile *LocaleFile) (*phraseapp.LocaleDetails, error) {

--- a/vendor/github.com/jpillora/backoff/README.md
+++ b/vendor/github.com/jpillora/backoff/README.md
@@ -1,0 +1,142 @@
+# Backoff
+
+A simple exponential backoff counter in Go (Golang)
+
+[![GoDoc](https://godoc.org/github.com/jpillora/backoff?status.svg)](https://godoc.org/github.com/jpillora/backoff) [![Circle CI](https://circleci.com/gh/jpillora/backoff.svg?style=shield)](https://circleci.com/gh/jpillora/backoff)
+
+### Install
+
+```
+$ go get -v github.com/jpillora/backoff
+```
+
+### Usage
+
+Backoff is a `time.Duration` counter. It starts at `Min`. After every call to `Duration()` it is  multiplied by `Factor`. It is capped at `Max`. It returns to `Min` on every call to `Reset()`. `Jitter` adds randomness ([see below](#example-using-jitter)). Used in conjunction with the `time` package.
+
+---
+
+#### Simple example
+
+``` go
+
+b := &backoff.Backoff{
+	//These are the defaults
+	Min:    100 * time.Millisecond,
+	Max:    10 * time.Second,
+	Factor: 2,
+	Jitter: false,
+}
+
+fmt.Printf("%s\n", b.Duration())
+fmt.Printf("%s\n", b.Duration())
+fmt.Printf("%s\n", b.Duration())
+
+fmt.Printf("Reset!\n")
+b.Reset()
+
+fmt.Printf("%s\n", b.Duration())
+```
+
+```
+100ms
+200ms
+400ms
+Reset!
+100ms
+```
+
+---
+
+#### Example using `net` package
+
+``` go
+b := &backoff.Backoff{
+    Max:    5 * time.Minute,
+}
+
+for {
+	conn, err := net.Dial("tcp", "example.com:5309")
+	if err != nil {
+		d := b.Duration()
+		fmt.Printf("%s, reconnecting in %s", err, d)
+		time.Sleep(d)
+		continue
+	}
+	//connected
+	b.Reset()
+	conn.Write([]byte("hello world!"))
+	// ... Read ... Write ... etc
+	conn.Close()
+	//disconnected
+}
+
+```
+
+---
+
+#### Example using `Jitter`
+
+Enabling `Jitter` adds some randomization to the backoff durations. [See Amazon's writeup of performance gains using jitter](http://www.awsarchitectureblog.com/2015/03/backoff.html). Seeding is not necessary but doing so gives repeatable results.
+
+```go
+import "math/rand"
+
+b := &backoff.Backoff{
+	Jitter: true,
+}
+
+rand.Seed(42)
+
+fmt.Printf("%s\n", b.Duration())
+fmt.Printf("%s\n", b.Duration())
+fmt.Printf("%s\n", b.Duration())
+
+fmt.Printf("Reset!\n")
+b.Reset()
+
+fmt.Printf("%s\n", b.Duration())
+fmt.Printf("%s\n", b.Duration())
+fmt.Printf("%s\n", b.Duration())
+```
+
+```
+100ms
+106.600049ms
+281.228155ms
+Reset!
+100ms
+104.381845ms
+214.957989ms
+```
+
+#### Documentation
+
+https://godoc.org/github.com/jpillora/backoff
+
+#### Credits
+
+Ported from some JavaScript written by [@tj](https://github.com/tj)
+
+#### MIT License
+
+Copyright © 2015 Jaime Pillora &lt;dev@jpillora.com&gt;
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+'Software'), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/vendor/github.com/jpillora/backoff/backoff.go
+++ b/vendor/github.com/jpillora/backoff/backoff.go
@@ -1,0 +1,79 @@
+package backoff
+
+import (
+	"math"
+	"math/rand"
+	"time"
+)
+
+//Backoff is a time.Duration counter. It starts at Min.
+//After every call to Duration() it is  multiplied by Factor.
+//It is capped at Max. It returns to Min on every call to Reset().
+//Used in conjunction with the time package.
+//
+// Backoff is not threadsafe, but the ForAttempt method can be
+// used concurrently if non-zero values for Factor, Max, and Min
+// are set on the Backoff shared among threads.
+type Backoff struct {
+	//Factor is the multiplying factor for each increment step
+	attempt, Factor float64
+	//Jitter eases contention by randomizing backoff steps
+	Jitter bool
+	//Min and Max are the minimum and maximum values of the counter
+	Min, Max time.Duration
+}
+
+//Returns the current value of the counter and then
+//multiplies it Factor
+func (b *Backoff) Duration() time.Duration {
+	d := b.ForAttempt(b.attempt)
+	b.attempt++
+	return d
+}
+
+// ForAttempt returns the duration for a specific attempt. This is useful if
+// you have a large number of independent Backoffs, but don't want use
+// unnecessary memory storing the Backoff parameters per Backoff. The first
+// attempt should be 0.
+//
+// ForAttempt is threadsafe iff non-zero values for Factor, Max, and Min
+// are set before any calls to ForAttempt are made.
+func (b *Backoff) ForAttempt(attempt float64) time.Duration {
+	if float64(b.Min) > float64(b.Max) {
+		return b.Max
+	}
+
+	//Zero-values are nonsensical, so we use
+	//them to apply defaults
+	if b.Min == 0 {
+		b.Min = 100 * time.Millisecond
+	}
+	if b.Max == 0 {
+		b.Max = 10 * time.Second
+	}
+	if b.Factor == 0 {
+		b.Factor = 2
+	}
+
+	//calculate this duration
+	dur := float64(b.Min) * math.Pow(b.Factor, attempt)
+	if b.Jitter == true {
+		dur = rand.Float64()*(dur-float64(b.Min)) + float64(b.Min)
+	}
+	//cap!
+	if dur > float64(b.Max) {
+		return b.Max
+	}
+	//return as a time.Duration
+	return time.Duration(dur)
+}
+
+//Resets the current value of the counter back to Min
+func (b *Backoff) Reset() {
+	b.attempt = 0
+}
+
+//Get the current backoff attempt
+func (b *Backoff) Attempt() float64 {
+	return b.attempt
+}


### PR DESCRIPTION
This change provides the user with better feedback when uploading locale files using the `push` command by waiting for an upload to actually be processed. Previously, the client only waited for the upload to finish and reported success when the file was transmitted. Now, after uploading a file, the upload's state is queried until it is either `success` or `error` and the user is shown a message accordingly.

Querying uses exponential backoff to avoid spamming the API with requests.