### PR TITLE
fix tests for check-for-update functionality

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,7 +7,4 @@ node {
 
   stage "Build"
   sh "bash build/build.sh"
-
-  stage "Push"
-  sh "bash build/push.sh"
 }

--- a/build/push.sh
+++ b/build/push.sh
@@ -6,8 +6,12 @@ BIN_DIR=$(cat ${WD}/.bin_dir)
 BUILD_VERSION=$(cat $BIN_DIR/.build_version)
 
 if ! which aws > /dev/null; then
-  apt-get update
-  apt-get install -y python-pip
+  if which yum > /dev/null 2>&1 ; then
+    yum install -y python2-pip
+  else
+    apt-get update
+    apt-get install -y python-pip
+  fi
   pip install awscli
 fi
 

--- a/check_for_update_test.go
+++ b/check_for_update_test.go
@@ -120,7 +120,7 @@ func TestGetLatestVersionWithInvalidCache(t *testing.T) {
 	}
 }
 
-func ExampleCheckForUpdateWithUpdateAvailable() {
+func ExampleCheckForUpdate_withUpdateAvailable() {
 	clearCache()
 	defer clearCache()
 
@@ -139,7 +139,7 @@ func ExampleCheckForUpdateWithUpdateAvailable() {
 	// You can get the latest version from https://phraseapp.com/en/cli.
 }
 
-func ExampleCheckForUpdateWithNoUpdateAvailable() {
+func ExampleCheckForUpdate_withNoUpdateAvailable() {
 	clearCache()
 	defer clearCache()
 
@@ -156,7 +156,7 @@ func ExampleCheckForUpdateWithNoUpdateAvailable() {
 	// Output:
 }
 
-func ExampleCheckForUpdateWithDevVersion() {
+func ExampleCheckForUpdate_withDevVersion() {
 	clearCache()
 	defer clearCache()
 

--- a/check_for_update_test.go
+++ b/check_for_update_test.go
@@ -33,8 +33,8 @@ func TestGetLatestVersionFromCache(t *testing.T) {
 	setupTestCache(expected)
 	defer clearCache()
 
-	v, _, ok := getLatestVersionFromCache()
-	if !ok {
+	v, _, err := getLatestVersionFromCache()
+	if err != nil {
 		t.Errorf("could not read version from cache!")
 	}
 
@@ -79,8 +79,8 @@ func TestGetLatestVersionWithoutCache(t *testing.T) {
 		t.Errorf("expected latest version to be %q, was %q", expected, v)
 	}
 
-	cv, _, ok := getLatestVersionFromCache()
-	if !ok {
+	cv, _, err := getLatestVersionFromCache()
+	if err != nil {
 		t.Errorf("could not read version from cache!")
 	}
 
@@ -108,8 +108,8 @@ func TestGetLatestVersionWithInvalidCache(t *testing.T) {
 		t.Errorf("expected latest version to be %q, was %q", expected, v)
 	}
 
-	cv, _, ok := getLatestVersionFromCache()
-	if !ok {
+	cv, _, err := getLatestVersionFromCache()
+	if err != nil {
 		t.Errorf("could not read version from cache!")
 	}
 

--- a/check_for_update_test.go
+++ b/check_for_update_test.go
@@ -11,6 +11,7 @@ import (
 
 func TestGetLatestVersionFromURL(t *testing.T) {
 	clearCache()
+	defer clearCache()
 
 	expected := "1.1.3"
 
@@ -64,6 +65,7 @@ func TestGetLatestVersionWithCache(t *testing.T) {
 
 func TestGetLatestVersionWithoutCache(t *testing.T) {
 	clearCache()
+	defer clearCache()
 
 	expected := "2.0.0"
 
@@ -120,6 +122,7 @@ func TestGetLatestVersionWithInvalidCache(t *testing.T) {
 
 func ExampleCheckForUpdateWithUpdateAvailable() {
 	clearCache()
+	defer clearCache()
 
 	resetVersion := setupFakeVersion("1.1.3")
 	defer resetVersion()
@@ -138,6 +141,7 @@ func ExampleCheckForUpdateWithUpdateAvailable() {
 
 func ExampleCheckForUpdateWithNoUpdateAvailable() {
 	clearCache()
+	defer clearCache()
 
 	latest := "1.7.0"
 
@@ -154,6 +158,7 @@ func ExampleCheckForUpdateWithNoUpdateAvailable() {
 
 func ExampleCheckForUpdateWithDevVersion() {
 	clearCache()
+	defer clearCache()
 
 	resetVersion := setupFakeVersion("1.1.3-dev")
 	defer resetVersion()


### PR DESCRIPTION
Forgot to update the tests when I moved from an "ok" `bool`to an `error` return value.