### PR TITLE
Pull locale error handling

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -2,6 +2,9 @@
 	"ImportPath": "github.com/phrase/phraseapp-client",
 	"GoVersion": "go1.7",
 	"GodepVersion": "v75",
+	"Packages": [
+		"./..."
+	],
 	"Deps": [
 		{
 			"ImportPath": "github.com/bgentry/speakeasy",
@@ -53,7 +56,7 @@
 		},
 		{
 			"ImportPath": "github.com/phrase/phraseapp-go/phraseapp",
-			"Rev": "cb69bf0eb63698feb66b572ce4cc4a8ef86a92fe"
+			"Rev": "451dac7981fa295483ea247e7b48c00a895e81ae"
 		},
 		{
 			"ImportPath": "gopkg.in/yaml.v2",

--- a/pull.go
+++ b/pull.go
@@ -7,7 +7,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	ct "github.com/daviddengcn/go-colortext"
+	"github.com/phrase/phraseapp-client/internal/print"
 	"github.com/phrase/phraseapp-go/phraseapp"
 )
 
@@ -79,7 +79,7 @@ func (target *Target) Pull(client *phraseapp.Client) error {
 		if err != nil {
 			return fmt.Errorf("%s for %s", err, localeFile.Path)
 		} else {
-			pullMessage(localeFile)
+			print.Success("Downloaded %s to %s", localeFile.Message(), localeFile.RelPath())
 		}
 		if Debug {
 			fmt.Fprintln(os.Stderr, strings.Repeat("-", 10))
@@ -189,17 +189,4 @@ func resolvedPath(localeFile *LocaleFile) (string, error) {
 	path = strings.Replace(path, "<tag>", localeFile.Tag, -1)
 
 	return path, nil
-}
-
-func pullMessage(localeFile *LocaleFile) {
-	local := localeFile.RelPath()
-	remote := localeFile.Message()
-	fmt.Print("Downloaded ")
-	ct.Foreground(ct.Green, true)
-	fmt.Print(remote)
-	ct.ResetColor()
-	fmt.Print(" to ")
-	ct.Foreground(ct.Green, true)
-	fmt.Print(local, "\n")
-	ct.ResetColor()
 }

--- a/pull_target.go
+++ b/pull_target.go
@@ -50,7 +50,7 @@ func (target *Target) CheckPreconditions() error {
 }
 
 func containsStars(target *Target) error {
-	if strings.Count(target.File, "*") > 0 {
+	if strings.Contains(target.File, "*") {
 		return fmt.Errorf("File pattern for 'pull' cannot include any 'stars' *. Please specify direct and valid paths with file name!\n %s#targets", docsConfigUrl)
 	}
 	return nil
@@ -66,7 +66,7 @@ func containsDuplicatePlaceholders(target *Target) error {
 
 	if len(duplicatedPlaceholders) > 0 {
 		dups := strings.Join(duplicatedPlaceholders, ", ")
-		return fmt.Errorf(fmt.Sprintf("%s can only occur once in a file pattern!", dups))
+		return fmt.Errorf("The following placeholders occur more than once (no duplicates allowed):\n%s", dups)
 	}
 
 	return nil

--- a/pull_target_test.go
+++ b/pull_target_test.go
@@ -96,7 +96,6 @@ func TestPreconditions(t *testing.T) {
 	}
 
 	// tag in placeholder but no tag provided
-	target.File = "some/path/en.yml"
 	target.Params.LocaleID = "en"
 	target.File = "some/<tag>/en.yml"
 	expect = "Using <tag> placeholder but no tags were provided."

--- a/pull_target_test.go
+++ b/pull_target_test.go
@@ -1,0 +1,64 @@
+package main
+
+import "testing"
+
+func getBaseTarget() *Target {
+	target := &Target{
+		File:          "./tests/<locale_code>.yml",
+		ProjectID:     "project-id",
+		AccessToken:   "access-token",
+		FileFormat:    "yml",
+		Params:        new(PullParams),
+		RemoteLocales: getBaseLocales(),
+	}
+	return target
+}
+
+func TestTargetFields(t *testing.T) {
+	target := getBaseTarget()
+
+	if target.File != "./tests/<locale_code>.yml" {
+		t.Errorf("Expected File to be %s and not %s", "./tests/<locale_code>.yml", target.File)
+	}
+
+	if target.AccessToken != "access-token" {
+		t.Errorf("Expected AccesToken to be %s and not %s", "access-token", target.AccessToken)
+	}
+
+	if target.ProjectID != "project-id" {
+		t.Errorf("Expected ProjectID to be %s and not %s", "project-id", target.ProjectID)
+	}
+
+	if target.FileFormat != "yml" {
+		t.Errorf("Expected FileFormat to be %s and not %s", "yml", target.FileFormat)
+	}
+}
+
+func TestPreconditions(t *testing.T) {
+	target := getBaseTarget()
+	for _, file := range []string{
+		"",
+		"no_extension",
+		"./<locale_code>/<locale_code>.yml",
+		"./**/**/en.yml",
+		"./**/*/*/en.yml",
+		"./**/*/en.yml",
+		"./en.yml",
+		"./**/*/<locale_name>/<locale_code>/<tag>.yml",
+	} {
+		target.File = file
+		if err := target.CheckPreconditions(); err == nil {
+			t.Errorf("CheckPrecondition did not fail for pattern: '%s'", file)
+		}
+	}
+
+	for _, file := range []string{
+		"./<tag>/<locale_code>.yml",
+		"./<locale_name>/<locale_code>/<tag>.yml",
+	} {
+		target.File = file
+		if err := target.CheckPreconditions(); err != nil {
+			t.Errorf("CheckPrecondition should not fail with: %s", err.Error())
+		}
+	}
+}

--- a/pull_test.go
+++ b/pull_test.go
@@ -6,69 +6,7 @@ import (
 	"testing"
 )
 
-func getBaseTarget() *Target {
-	target := &Target{
-		File:          "./tests/<locale_code>.yml",
-		ProjectID:     "project-id",
-		AccessToken:   "access-token",
-		FileFormat:    "yml",
-		Params:        new(PullParams),
-		RemoteLocales: getBaseLocales(),
-	}
-	return target
-}
-
-func TestPullPreconditions(t *testing.T) {
-	target := getBaseTarget()
-	for _, file := range []string{
-		"",
-		"no_extension",
-		"./<locale_code>/<locale_code>.yml",
-		"./**/**/en.yml",
-		"./**/*/*/en.yml",
-		"./**/*/en.yml",
-		"./en.yml",
-		"./**/*/<locale_name>/<locale_code>/<tag>.yml",
-	} {
-		target.File = file
-		if err := target.CheckPreconditions(); err == nil {
-			t.Errorf("CheckPrecondition did not fail for pattern: '%s'", file)
-		}
-	}
-
-	for _, file := range []string{
-		"./<tag>/<locale_code>.yml",
-		"./<locale_name>/<locale_code>/<tag>.yml",
-	} {
-		target.File = file
-		if err := target.CheckPreconditions(); err != nil {
-			t.Errorf("CheckPrecondition should not fail with: %s", err.Error())
-		}
-	}
-}
-
-func TestTargetFields(t *testing.T) {
-	target := getBaseTarget()
-
-	if target.File != "./tests/<locale_code>.yml" {
-		t.Errorf("Expected File to be %s and not %s", "./tests/<locale_code>.yml", target.File)
-	}
-
-	if target.AccessToken != "access-token" {
-		t.Errorf("Expected AccesToken to be %s and not %s", "access-token", target.AccessToken)
-	}
-
-	if target.ProjectID != "project-id" {
-		t.Errorf("Expected ProjectID to be %s and not %s", "project-id", target.ProjectID)
-	}
-
-	if target.FileFormat != "yml" {
-		t.Errorf("Expected FileFormat to be %s and not %s", "yml", target.FileFormat)
-	}
-
-}
-
-func TestTargetLocaleFiles(t *testing.T) {
+func TestPullLocaleFiles(t *testing.T) {
 	target := getBaseTarget()
 	localeFiles, err := target.LocaleFiles()
 
@@ -102,7 +40,7 @@ func TestTargetLocaleFiles(t *testing.T) {
 	}
 }
 
-func TestReplacePlaceholders(t *testing.T) {
+func TestResolvedPath(t *testing.T) {
 	target := getBaseTarget()
 	target.File = "./<locale_code>/<tag>/<locale_name>.yml"
 	localeFile := &LocaleFile{
@@ -110,9 +48,9 @@ func TestReplacePlaceholders(t *testing.T) {
 		Code: "en",
 		ID:   "en-locale-id",
 		Tag:  "abc",
-		Path: "",
+		Path: target.File,
 	}
-	newPath, err := target.ReplacePlaceholders(localeFile)
+	newPath, err := resolvedPath(localeFile)
 	if err != nil {
 		t.Errorf(err.Error())
 		t.Fail()

--- a/push.go
+++ b/push.go
@@ -32,7 +32,7 @@ func (cmd *PushCommand) Run() error {
 		return err
 	}
 
-	sources, err := SourcesFromConfig(cmd)
+	sources, err := SourcesFromConfig(cmd.Config)
 	if err != nil {
 		return err
 	}

--- a/push_source.go
+++ b/push_source.go
@@ -9,23 +9,22 @@ import (
 	yaml "gopkg.in/yaml.v2"
 )
 
-func SourcesFromConfig(cmd *PushCommand) (Sources, error) {
-	if cmd.Config.Sources == nil || len(cmd.Config.Sources) == 0 {
+func SourcesFromConfig(config phraseapp.Config) (Sources, error) {
+	if config.Sources == nil || len(config.Sources) == 0 {
 		return nil, fmt.Errorf("no sources for upload specified")
 	}
 
 	tmp := struct {
 		Sources Sources
 	}{}
-	err := yaml.Unmarshal(cmd.Config.Sources, &tmp)
+	err := yaml.Unmarshal(config.Sources, &tmp)
 	if err != nil {
 		return nil, err
 	}
 	srcs := tmp.Sources
 
-	token := cmd.Credentials.Token
-	projectId := cmd.Config.DefaultProjectID
-	fileFormat := cmd.Config.DefaultFileFormat
+	projectId := config.DefaultProjectID
+	fileFormat := config.DefaultFileFormat
 
 	validSources := []*Source{}
 	for _, source := range srcs {
@@ -34,9 +33,6 @@ func SourcesFromConfig(cmd *PushCommand) (Sources, error) {
 		}
 		if source.ProjectID == "" {
 			source.ProjectID = projectId
-		}
-		if source.AccessToken == "" {
-			source.AccessToken = token
 		}
 		if source.Params == nil {
 			source.Params = new(phraseapp.UploadParams)

--- a/shared.go
+++ b/shared.go
@@ -10,16 +10,18 @@ import (
 	"github.com/phrase/phraseapp-go/phraseapp"
 )
 
-var Debug bool
+var (
+	Debug             bool
+	separator         = string(os.PathSeparator)
+	placeholderRegexp = regexp.MustCompile("<(locale_name|locale_code|tag)>")
+	localePlaceholder = regexp.MustCompile("<(locale_name|locale_code)>")
+	tagPlaceholder    = regexp.MustCompile("<(tag)>")
+)
 
-var separator = string(os.PathSeparator)
-
-var placeholderRegexp = regexp.MustCompile("<(locale_name|locale_code|tag)>")
-var localePlaceholder = regexp.MustCompile("<(locale_name|locale_code)>")
-var tagPlaceholder = regexp.MustCompile("<(tag)>")
-
-const docsBaseUrl = "https://phraseapp.com/docs"
-const docsConfigUrl = docsBaseUrl + "/developers/cli/configuration"
+const (
+	docsBaseUrl   = "https://phraseapp.com/docs"
+	docsConfigUrl = docsBaseUrl + "/developers/cli/configuration"
+)
 
 func containsAnyPlaceholders(s string) bool {
 	return (localePlaceholder.MatchString(s) || tagPlaceholder.MatchString(s))

--- a/shared.go
+++ b/shared.go
@@ -14,13 +14,23 @@ var Debug bool
 
 var separator = string(os.PathSeparator)
 
-var placeholderRegexp = regexp.MustCompile("<(locale_name|tag|locale_code)>")
+var placeholderRegexp = regexp.MustCompile("<(locale_name|locale_code|tag)>")
+var localePlaceholder = regexp.MustCompile("<(locale_name|locale_code)>")
+var tagPlaceholder = regexp.MustCompile("<(tag)>")
 
 const docsBaseUrl = "https://phraseapp.com/docs"
 const docsConfigUrl = docsBaseUrl + "/developers/cli/configuration"
 
 func containsAnyPlaceholders(s string) bool {
-	return placeholderRegexp.MatchString(s)
+	return (localePlaceholder.MatchString(s) || tagPlaceholder.MatchString(s))
+}
+
+func containsLocalePlaceholder(s string) bool {
+	return localePlaceholder.MatchString(s)
+}
+
+func containsTagPlaceholder(s string) bool {
+	return tagPlaceholder.MatchString(s)
 }
 
 func docsFormatsUrl(formatName string) string {
@@ -29,9 +39,7 @@ func docsFormatsUrl(formatName string) string {
 
 func ValidPath(file, formatName, formatExtension string) error {
 	if strings.TrimSpace(file) == "" {
-		return fmt.Errorf(
-			"File patterns may not be empty!\nFor more information see %s", docsConfigUrl,
-		)
+		return fmt.Errorf("File patterns may not be empty!\nFor more information see %s", docsConfigUrl)
 	}
 
 	fileExtension := strings.Trim(filepath.Ext(file), ".")
@@ -66,6 +74,7 @@ func LocalesForProjects(client *phraseapp.Client, projectLocales ProjectLocales)
 			if err != nil {
 				return nil, err
 			}
+
 			projectIdToLocales[pid] = remoteLocales
 		}
 	}

--- a/shared.go
+++ b/shared.go
@@ -7,7 +7,6 @@ import (
 	"regexp"
 	"strings"
 
-	ct "github.com/daviddengcn/go-colortext"
 	"github.com/phrase/phraseapp-go/phraseapp"
 )
 
@@ -118,26 +117,22 @@ func isDir(path string) bool {
 	return stat.IsDir()
 }
 
-func sharedMessage(method string, localeFile *LocaleFile) {
-	local := localeFile.RelPath()
+func createFile(path string) error {
+	err := Exists(path)
+	if err != nil {
+		absDir := filepath.Dir(path)
+		err := Exists(absDir)
+		if err != nil {
+			os.MkdirAll(absDir, 0700)
+		}
 
-	if method == "pull" {
-		remote := localeFile.Message()
-		fmt.Print("Downloaded ")
-		ct.Foreground(ct.Green, true)
-		fmt.Print(remote)
-		ct.ResetColor()
-		fmt.Print(" to ")
-		ct.Foreground(ct.Green, true)
-		fmt.Print(local, "\n")
-		ct.ResetColor()
-	} else {
-		fmt.Print("Uploaded ")
-		ct.Foreground(ct.Green, true)
-		fmt.Print(local)
-		ct.ResetColor()
-		fmt.Println(" successfully.")
+		f, err := os.Create(path)
+		if err != nil {
+			return err
+		}
+		defer f.Close()
 	}
+	return nil
 }
 
 func isNotFound(err error) bool {

--- a/vendor/github.com/phrase/phraseapp-go/phraseapp/response.go
+++ b/vendor/github.com/phrase/phraseapp-go/phraseapp/response.go
@@ -28,7 +28,12 @@ func handleResponseStatus(resp *http.Response, expectedStatus int) error {
 	case http.StatusForbidden:
 		return fmt.Errorf("%d - %s\nYou are not authorized to perform the requested action on the requested resource. Check if your provided access_token has the correct scope.%s", status, http.StatusText(status), further())
 	case http.StatusNotFound:
-		return fmt.Errorf("%d - Resource Not Found\nThe resource you requested or referenced resources you required do either not exist or you do not have the authorization to request this resource.", status)
+		var err *ErrorResponse
+		decodeErr := json.NewDecoder(resp.Body).Decode(&err)
+		if decodeErr != nil {
+			return fmt.Errorf("%d - Resource Not Found\nThe resource you requested or referenced resources you required do either not exist or you do not have the authorization to request this resource.", status)
+		}
+		return err
 	case 422:
 		e := new(ValidationErrorResponse)
 		err := json.NewDecoder(resp.Body).Decode(&e)


### PR DESCRIPTION
1. part - 31effc792ab020e6e2513d576ba89b688d927e3f

* Push + Pull `config parsing` does not set `access_token` anymore (as it was unnecessary)
* Push + Pull `config parsing` now receives `cmd.Config` instead of `Push/PullCommand`
* Moved Pull targets in own file

2. part - all after 31effc792ab020e6e2513d576ba89b688d927e3f

* Refactored pull preconditions
* Locales are now validated during pull (wrong locale_id parameters can actually be detected)
* Added some specs that actually fail for the right reasons