### PR TITLE
Show full error when create project failed

### DIFF
--- a/init.go
+++ b/init.go
@@ -223,8 +223,6 @@ func (cmd *InitCommand) newProject() error {
 	if err != nil {
 		if strings.Contains(err.Error(), "401") {
 			return fmt.Errorf("Your access token %s is not valid for the 'write' scope. Please create a new Access Token with read and write scope.", cmd.Credentials.Token)
-		} else if strings.Contains(err.Error(), "Validation failed") {
-			return fmt.Errorf("Validation failed. Please try a different token.")
 		}
 		return err
 	}


### PR DESCRIPTION
Try a different token message was not a helpful error message in this case. Instead it now returns the full error message which contains the reason for a failure e.g. the project name already exists