### PR TITLE
Windows escaping

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,10 @@ language: go
 
 sudo: false
 
+os:
+    - linux
+    - osx
 go:
-    - 1.7.4
-    - 1.8rc1
+    - 1.8.x
 
 script: make all

--- a/internal/placeholders/placeholders.go
+++ b/internal/placeholders/placeholders.go
@@ -59,7 +59,7 @@ func Resolve(s, pattern string) (map[string]string, error) {
 
 	for _, placeholder := range stringz.RemoveDuplicates(placeholders) {
 		placeholder = regexp.QuoteMeta(placeholder)
-		placeholderRE := fmt.Sprintf("(?P%s[^%s]+)", placeholder, string(filepath.Separator)) // build named subexpression (capturing group) from placeholder
+		placeholderRE := fmt.Sprintf("(?P%s[^/]+)", placeholder) // build named subexpression (capturing group) from placeholder
 		patternRE = strings.Replace(patternRE, placeholder, placeholderRE, -1)
 	}
 

--- a/push.go
+++ b/push.go
@@ -263,6 +263,7 @@ func (source *Source) getRemoteLocaleForLocaleFile(localeFile *LocaleFile) *phra
 }
 
 func (localeFile *LocaleFile) fillFromPath(path, pattern string) {
+	path = filepath.ToSlash(path)
 	pathStart, patternStart, pathEnd, patternEnd, err := paths.SplitAtDirGlobOperator(path, pattern)
 	if err != nil {
 		print.Error(err)


### PR DESCRIPTION
This solves the regex error on Windows with placeholders in the path https://github.com/phrase/phraseapp-client/issues/98
Also update go version in travis to fix the builds.