### PR TITLE
Improved Windows setup

### DIFF
--- a/build/innosetup/phraseapp-client.iss
+++ b/build/innosetup/phraseapp-client.iss
@@ -24,10 +24,33 @@ Compression=lzma
 SolidCompression=yes
 
 [Files]
-Source: "../../dist/phraseapp_windows_amd64.exe"; DestDir: "{app}\phraseapp"; DestName: "phraseapp.exe"; Flags: ignoreversion
+Source: "../../dist/phraseapp_windows_amd64.exe"; DestDir: "{app}"; DestName: "phraseapp.exe"; Flags: ignoreversion
 ; NOTE: Don't use "Flags: ignoreversion" on any shared system files
+
+[Registry]
+Root: HKLM; Subkey: "SYSTEM\CurrentControlSet\Control\Session Manager\Environment"; \
+    ValueType: expandsz; ValueName: "Path"; ValueData: "{olddata};{app}"; \
+    Check: NeedsAddPath('C:\foo')
 
 [Icons]
 Name: "{group}\PhraseApp Client"; Filename: "{app}"
 Name: "{group}\{cm:UninstallProgram,PhraseApp Client}"; Filename: "{uninstallexe}"
 Name: "{commondesktop}\PhraseApp Client"; Filename: "{app}\phraseapp.exe";
+
+[Code]
+function NeedsAddPath(Param: string): boolean;
+var
+  OrigPath: string;
+begin
+  if not RegQueryStringValue(HKEY_LOCAL_MACHINE,
+    'SYSTEM\CurrentControlSet\Control\Session Manager\Environment',
+    'Path', OrigPath)
+  then begin
+    Result := True;
+    exit;
+  end;
+  { look for the path with leading and trailing semicolon }
+  { Pos() returns 0 if not found }
+  Result := Pos(';' + Param + ';', ';' + OrigPath + ';') = 0;
+end;
+

--- a/build/innosetup/phraseapp-client.iss
+++ b/build/innosetup/phraseapp-client.iss
@@ -32,6 +32,9 @@ Root: HKLM; Subkey: "SYSTEM\CurrentControlSet\Control\Session Manager\Environmen
     ValueType: expandsz; ValueName: "Path"; ValueData: "{olddata};{app}"; \
     Check: NeedsAddPath('C:\foo')
 
+[Setup]
+AlwaysRestart = yes
+
 [Icons]
 Name: "{group}\PhraseApp Client"; Filename: "{app}"
 Name: "{group}\{cm:UninstallProgram,PhraseApp Client}"; Filename: "{uninstallexe}"

--- a/build/innosetup/phraseapp-client.iss
+++ b/build/innosetup/phraseapp-client.iss
@@ -31,7 +31,6 @@ Source: "../../dist/phraseapp_windows_amd64.exe"; DestDir: "{app}"; DestName: "p
 [Registry]
 Root: HKLM; Subkey: "SYSTEM\CurrentControlSet\Control\Session Manager\Environment"; \
     ValueType: expandsz; ValueName: "Path"; ValueData: "{olddata};{app}"; \
-    Check: NeedsAddPath('C:\foo')
 
 [Setup]
 AlwaysRestart = yes
@@ -40,21 +39,3 @@ AlwaysRestart = yes
 Name: "{group}\PhraseApp Client"; Filename: "{app}"
 Name: "{group}\{cm:UninstallProgram,PhraseApp Client}"; Filename: "{uninstallexe}"
 Name: "{commondesktop}\PhraseApp Client"; Filename: "{app}\phraseapp.exe";
-
-[Code]
-function NeedsAddPath(Param: string): boolean;
-var
-  OrigPath: string;
-begin
-  if not RegQueryStringValue(HKEY_LOCAL_MACHINE,
-    'SYSTEM\CurrentControlSet\Control\Session Manager\Environment',
-    'Path', OrigPath)
-  then begin
-    Result := True;
-    exit;
-  end;
-  { look for the path with leading and trailing semicolon }
-  { Pos() returns 0 if not found }
-  Result := Pos(';' + Param + ';', ';' + OrigPath + ';') = 0;
-end;
-

--- a/build/innosetup/phraseapp-client.iss
+++ b/build/innosetup/phraseapp-client.iss
@@ -13,6 +13,7 @@ AppPublisher=PhraseApp GmbH
 AppPublisherURL=https://phraseapp.com/cli
 AppSupportURL=https://phraseapp.com/cli
 AppUpdatesURL=https://phraseapp.com/cli
+ArchitecturesAllowed=x64
 DefaultDirName={pf}\PhraseApp
 DefaultGroupName=PhraseApp-Client
 DisableProgramGroupPage=yes


### PR DESCRIPTION
To make this a fully featured setup, I added some code to the installer, that will set the %PATH% variable in Windows and asks for a restart after the setup. This way we make sure that the CLI will be accessible from the CMD. Further information can be found in the commit notes.