### PR TITLE
Support rate limit for locale downloads

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -38,7 +38,7 @@
   branch = "master"
   name = "github.com/phrase/phraseapp-go"
   packages = ["phraseapp"]
-  revision = "598d226e84380e92d4893f76d7eec22211f4fb27"
+  revision = "c74434256e796842fa858bbe59d1557196c2f22f"
 
 [[projects]]
   name = "gopkg.in/yaml.v2"

--- a/pull.go
+++ b/pull.go
@@ -6,11 +6,16 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/phrase/phraseapp-client/internal/paths"
 	"github.com/phrase/phraseapp-client/internal/placeholders"
 	"github.com/phrase/phraseapp-client/internal/print"
 	"github.com/phrase/phraseapp-go/phraseapp"
+)
+
+const (
+	timeoutInMinutes = 30
 )
 
 type PullCommand struct {
@@ -72,7 +77,12 @@ func (target *Target) Pull(client *phraseapp.Client, branch string) error {
 		return err
 	}
 
+	startedAt := time.Now()
 	for _, localeFile := range localeFiles {
+		if time.Now().Sub(startedAt).Minutes() >= timeoutInMinutes {
+			return fmt.Errorf("Timeout of %d minutes exceeded", timeoutInMinutes)
+		}
+
 		err := createFile(localeFile.Path)
 		if err != nil {
 			return err
@@ -118,14 +128,15 @@ func (target *Target) DownloadAndWriteToFile(client *phraseapp.Client, localeFil
 
 	res, err := client.LocaleDownload(target.ProjectID, localeFile.ID, downloadParams)
 	if err != nil {
-		return err
+		if rateLimitError, ok := (err).(*phraseapp.RateLimitingError); ok {
+			checkRateLimit(rateLimitError)
+		} else {
+			return err
+		}
 	}
 
 	err = ioutil.WriteFile(localeFile.Path, res, 0700)
-	if err != nil {
-		return err
-	}
-	return nil
+	return err
 }
 
 func (target *Target) LocaleFiles() (LocaleFiles, error) {
@@ -161,6 +172,15 @@ func (target *Target) LocaleFiles() (LocaleFiles, error) {
 	}
 
 	return files, nil
+}
+
+func checkRateLimit(rateLimitError *phraseapp.RateLimitingError) {
+	if rateLimitError.Remaining == 0 {
+		reset := rateLimitError.Reset
+		resetTime := reset.Add(time.Second * 1).Sub(time.Now())
+		fmt.Printf("Rate limit exceeded. Download will resume in %d seconds\n", int64(resetTime.Seconds()))
+		time.Sleep(resetTime)
+	}
 }
 
 func createLocaleFile(target *Target, remoteLocale *phraseapp.Locale) (*LocaleFile, error) {


### PR DESCRIPTION
Support rate limit in locale downloads. When the rate limit is reached the client will wait for until the rate limit is reset. If the downloads are not finished after a total of 30 minutes the client will exit