### PR TITLE
Branching: fix pull issue for multiple projects in .phraseapp.yml

### DIFF
--- a/pull.go
+++ b/pull.go
@@ -42,6 +42,9 @@ func (cmd *PullCommand) Run() error {
 	for _, target := range targets {
 		val, ok := projectIdToLocales[LocaleCacheKey{target.ProjectID, cmd.Branch}]
 		if !ok || len(val) == 0 {
+			if cmd.Branch != "" {
+				continue
+			}
 			return fmt.Errorf("Could not find any locales for project %q", target.ProjectID)
 		}
 		target.RemoteLocales = val

--- a/shared.go
+++ b/shared.go
@@ -28,7 +28,9 @@ func LocalesForProjects(client *phraseapp.Client, projectLocales ProjectLocales,
 		if _, ok := projectIdToLocales[key]; !ok {
 			remoteLocales, err := RemoteLocales(client, key)
 			if err != nil {
-				if branch != "" {
+				if _, ok := (err).(phraseapp.ErrNotFound); ok && branch != "" {
+					// skip this key if we targeted a branch in
+					// a project which does not exist
 					continue
 				}
 				return nil, err

--- a/shared.go
+++ b/shared.go
@@ -1,6 +1,8 @@
 package main
 
-import "github.com/phrase/phraseapp-go/phraseapp"
+import (
+	"github.com/phrase/phraseapp-go/phraseapp"
+)
 
 var Debug bool
 
@@ -16,7 +18,6 @@ type LocaleCacheKey struct {
 type LocaleCache map[LocaleCacheKey][]*phraseapp.Locale
 
 func LocalesForProjects(client *phraseapp.Client, projectLocales ProjectLocales, branch string) (LocaleCache, error) {
-
 	projectIdToLocales := LocaleCache{}
 	for _, pid := range projectLocales.ProjectIds() {
 		key := LocaleCacheKey{
@@ -27,6 +28,9 @@ func LocalesForProjects(client *phraseapp.Client, projectLocales ProjectLocales,
 		if _, ok := projectIdToLocales[key]; !ok {
 			remoteLocales, err := RemoteLocales(client, key)
 			if err != nil {
+				if branch != "" {
+					continue
+				}
 				return nil, err
 			}
 


### PR DESCRIPTION
When pulling using a configuration with several projects. Adding the
--branch option does not work, if only one of the projects has this
branch. We fix this by ignoring the projects which do not have the
specified branch.