### PR TITLE
Multiple tags placeholder

### DIFF
--- a/pull.go
+++ b/pull.go
@@ -156,17 +156,18 @@ func (target *Target) LocaleFiles() (LocaleFiles, error) {
 			return nil, err
 		}
 
-		localeFile, err := createLocaleFile(target, remoteLocale)
-		if err != nil {
-			return nil, err
+		for _, tag := range target.GetTags() {
+			localeFile, err := createLocaleFile(target, remoteLocale, tag)
+			if err != nil {
+				return nil, err
+			}
+
+			files = append(files, localeFile)
 		}
-
-		files = append(files, localeFile)
-
 	} else if placeholders.ContainsLocalePlaceholder(target.File) {
 		// multiple locales were requested
 		for _, remoteLocale := range target.RemoteLocales {
-			localeFile, err := createLocaleFile(target, remoteLocale)
+			localeFile, err := createLocaleFile(target, remoteLocale, "")
 			if err != nil {
 				return nil, err
 			}
@@ -190,12 +191,12 @@ func waitForRateLimit(rateLimitError *phraseapp.RateLimitingError) {
 	}
 }
 
-func createLocaleFile(target *Target, remoteLocale *phraseapp.Locale) (*LocaleFile, error) {
+func createLocaleFile(target *Target, remoteLocale *phraseapp.Locale, tag string) (*LocaleFile, error) {
 	localeFile := &LocaleFile{
 		Name:       remoteLocale.Name,
 		ID:         remoteLocale.ID,
 		Code:       remoteLocale.Code,
-		Tag:        target.GetTag(),
+		Tag:        tag,
 		FileFormat: target.GetFormat(),
 		Path:       target.File,
 	}

--- a/pull.go
+++ b/pull.go
@@ -176,7 +176,7 @@ func (target *Target) LocaleFiles() (LocaleFiles, error) {
 		}
 	} else {
 		// no local files match remote locale
-		return nil, fmt.Errorf("could not find any files on your system that matches the locales for porject %q", target.ProjectID)
+		return nil, fmt.Errorf("could not find any files on your system that matches the locales for project %q", target.ProjectID)
 	}
 
 	return files, nil

--- a/pull_target.go
+++ b/pull_target.go
@@ -88,9 +88,9 @@ func containsAmbiguousLocaleInformation(target *Target) error {
 }
 
 func containsInvalidTagInformation(target *Target) error {
-	if target.GetTag() == "" && placeholders.ContainsTagPlaceholder(target.File) {
+	if len(target.GetTags()) == 0 && placeholders.ContainsTagPlaceholder(target.File) {
 		// tag provided but no params
-		return fmt.Errorf("Using <tag> placeholder but no tags were provided. Please specify a 'tag: \"my_tag\"' in the params section.")
+		return fmt.Errorf("Using <tag> placeholder but no tags were provided. Please specify 'tags: \"my_tag\"' in the params section.")
 	}
 	return nil
 }
@@ -135,11 +135,20 @@ func (t *Target) GetLocaleID() string {
 	return ""
 }
 
-func (t *Target) GetTag() string {
-	if t.Params != nil && t.Params.Tag != nil {
-		return *t.Params.Tag
+func (t *Target) GetTags() []string {
+	tagList := []string{}
+	var tagsParam string
+	if t.Params != nil && t.Params.Tags != nil {
+		tagsParam = *t.Params.Tags
+	} else if t.Params != nil && t.Params.Tag != nil {
+		tagsParam = *t.Params.Tag
 	}
-	return ""
+
+	if tagsParam != "" {
+		tagsParam = strings.Replace(tagsParam, " ", "", -1)
+		tagList = strings.Split(tagsParam, ",")
+	}
+	return tagList
 }
 
 func TargetsFromConfig(config phraseapp.Config) (Targets, error) {

--- a/pull_test.go
+++ b/pull_test.go
@@ -60,3 +60,35 @@ func TestResolvedPath(t *testing.T) {
 		t.Errorf("Expected the new path to eql '%s' and not %s", "/en/abc/english.yml", newPath)
 	}
 }
+
+func TestLocaleFilesWithMultipleTags(t *testing.T) {
+	target := &Target{
+		File:          "./tests/<locale_code>/<tag>.yml",
+		ProjectID:     "project-id",
+		AccessToken:   "access-token",
+		FileFormat:    "yml",
+		Params:        new(PullParams),
+		RemoteLocales: getBaseLocales(),
+	}
+	tags := "abc,abc2"
+	target.Params.Tags = &tags
+	target.Params.LocaleID = "en-locale-id"
+
+	files, err := target.LocaleFiles()
+	if err != nil {
+		t.Errorf(err.Error())
+		t.Fail()
+	}
+
+	if len(files) != 2 {
+		t.Errorf("Expected 2 files and and not %d", len(files))
+	}
+
+	if !strings.HasSuffix(files[0].Path, "/tests/en/abc.yml") {
+		t.Errorf("File path is '%s' and should end with '%s'", files[0].Path, "/tests/en/abc.yml")
+	}
+
+	if !strings.HasSuffix(files[1].Path, "/tests/en/abc2.yml") {
+		t.Errorf("File path is '%s' and should end with '%s'", files[1].Path, "/tests/en/abc2.yml")
+	}
+}


### PR DESCRIPTION
Add support for the new `tags` parameter for the tag placeholder. Makes it also possible to use multiple tags for the placeholder. Should resolve: https://github.com/phrase/phraseapp-client/issues/148