### PR TITLE
Automate client release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - checkout
       - setup_remote_docker
-      - run: make release
+      - run: ./build/release.sh
 workflows:
   version: 2
   test:
@@ -25,6 +25,5 @@ workflows:
       - release:
           filters:
             branches:
-              ignore: /.*/
-            tags:
-              only: /v[0-9]+(\.[0-9]+)*(-.*)*/
+              only:
+                - master

--- a/build/release.sh
+++ b/build/release.sh
@@ -2,6 +2,21 @@
 
 set -eo pipefail
 
+# validate that master is checked out and head points to origin/master
+BRANCH=$(git rev-parse --abbrev-ref HEAD)
+if [ $BRANCH != 'master' ]; then
+    echo "Not on master branch. Aborting"
+    exit 1
+fi
+
+ HEADHASH=$(git rev-parse HEAD)
+ UPSTREAMHASH=$(git rev-parse master@{upstream})
+
+ if [ "$HEADHASH" != "$UPSTREAMHASH" ]; then
+   echo "Not up to date with origin/master. Aborting"
+   exit 1
+ fi
+
 # Validate current tag against version
 current_tag=$(git describe --tags --abbrev=0)
 client_version=$(cat .version)


### PR DESCRIPTION
Now the only command to release a client is `make release`. The script will also validate that origin/master is checked out before tagging a release