### PR TITLE
Disable auto releasing until CircleCI Docker build is fixed

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,10 +20,10 @@ workflows:
   test:
     jobs:
       - test
-  release:
-    jobs:
-      - release:
-          filters:
-            branches:
-              only:
-                - master
+  # release:
+  #   jobs:
+  #     - release:
+  #         filters:
+  #           branches:
+  #             only:
+  #               - master


### PR DESCRIPTION
Currently the release steps fails on CircleCI due to an X server issue. Disable auto release until this is resolved on CircleCI