### PR TITLE
fix: typo with the word succeeded

### DIFF
--- a/push.go
+++ b/push.go
@@ -149,7 +149,7 @@ func (source *Source) Push(client *phraseapp.Client, waitForResults bool, branch
 			taskResult := make(chan string, 1)
 			taskErr := make(chan error, 1)
 
-			fmt.Printf("Upload ID: %s, filename: %s suceeded. Waiting for your file to be processed... ", upload.ID, upload.Filename)
+			fmt.Printf("Upload ID: %s, filename: %s succeeded. Waiting for your file to be processed... ", upload.ID, upload.Filename)
 			spinner.While(func() {
 				result, err := getUploadResult(client, source.ProjectID, upload, branch)
 				taskResult <- result


### PR DESCRIPTION
Fix a typo with the word succeeded in the CLI output