### PR TITLE
Fix path for innosetup 6

### DIFF
--- a/build/innosetup/docker_build.sh
+++ b/build/innosetup/docker_build.sh
@@ -4,8 +4,8 @@ set -e
 
 cd /client
 cp LICENSE build/innosetup/
-wine '/root/.wine/drive_c/Program Files/Inno Setup 5/ISCC.exe' build/innosetup/phraseapp-client.iss
-wine '/root/.wine/drive_c/Program Files/Inno Setup 5/ISCC.exe' build/innosetup/phraseapp-client-386.iss
+wine '/root/.wine/drive_c/Program Files/Inno Setup 6/ISCC.exe' build/innosetup/phraseapp-client.iss
+wine '/root/.wine/drive_c/Program Files/Inno Setup 6/ISCC.exe' build/innosetup/phraseapp-client-386.iss
 mv build/innosetup/Output/phraseapp_setup_386.exe dist/phraseapp_windows_setup_386.exe
 mv build/innosetup/Output/phraseapp_setup.exe dist/phraseapp_windows_setup.exe
 rm build/innosetup/LICENSE

--- a/build/innosetup/phraseapp-client-386.iss
+++ b/build/innosetup/phraseapp-client-386.iss
@@ -21,6 +21,7 @@ OutputBaseFilename=phraseapp_setup_386
 SetupIconFile=parrot.ico
 Compression=lzma
 SolidCompression=yes
+WizardStyle=modern
 
 [Files]
 Source: "../../dist/phraseapp_windows_386.exe"; DestDir: "{app}"; DestName: "phraseapp.exe"; Flags: ignoreversion

--- a/build/innosetup/phraseapp-client.iss
+++ b/build/innosetup/phraseapp-client.iss
@@ -22,6 +22,7 @@ OutputBaseFilename=phraseapp_setup
 SetupIconFile=parrot.ico
 Compression=lzma
 SolidCompression=yes
+WizardStyle=modern
 
 [Files]
 Source: "../../dist/phraseapp_windows_amd64.exe"; DestDir: "{app}"; DestName: "phraseapp.exe"; Flags: ignoreversion


### PR DESCRIPTION
New InnoSetup version was released which is installed to a different path. Additionally installer has now a more modern look