### PR TITLE
Add use-local-branch-name option

### DIFF
--- a/branches.go
+++ b/branches.go
@@ -1,0 +1,79 @@
+package main
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func usedBranchName(useLocalBranchNameFlag bool, branchParam string) (string, error) {
+	if useLocalBranchName(useLocalBranchNameFlag) && branchParam == "" {
+		gitBranch, gitErr := checkedOutGitBranch()
+		if gitErr != nil || gitBranch == "" {
+			mercurialBranch, mercurialErr := checkedOutMercurialBranch()
+			if mercurialErr != nil || mercurialBranch == "" {
+				return "", errors.New("could not determine neither a git nor a mercurial branch")
+			} else if mercurialErr != nil {
+				return "", mercurialErr
+			}
+
+			return mercurialBranch, nil
+		} else if gitErr != nil {
+			return "", gitErr
+		}
+
+		return gitBranch, nil
+	}
+
+	return branchParam, nil
+}
+
+func useLocalBranchName(useLocalBranchNameFlag bool) bool {
+	return os.Getenv("PHRASEAPP_USE_LOCAL_BRANCH_NAME") == "true" || useLocalBranchNameFlag
+}
+
+func checkedOutGitBranch() (string, error) {
+	gitPath := os.Getenv("PHRASEAPP_GIT_BINARY")
+	if gitPath == "" {
+		systemGitPath, err := exec.LookPath("git")
+		if err != nil {
+			return "", errors.New("git is not installed")
+		}
+		gitPath = systemGitPath
+	}
+
+	gitCmd := exec.Command(gitPath, "rev-parse", "--abbrev-ref", "HEAD")
+	out, err := gitCmd.Output()
+	if err != nil {
+		return "", err
+	}
+
+	gitBranch := strings.TrimSpace(string(out))
+	if gitBranch == "HEAD" {
+		return "", errors.New("no git branched checked out")
+	}
+
+	return gitBranch, nil
+}
+
+func checkedOutMercurialBranch() (string, error) {
+	hgPath := os.Getenv("PHRASEAPP_MERCURIAL_BINARY")
+	if hgPath == "" {
+		systemHgPath, err := exec.LookPath("hg")
+		if err != nil {
+			return "", errors.New("hg is not installed")
+		}
+		hgPath = systemHgPath
+	}
+
+	hgCmd := exec.Command(hgPath, "identify", "-b")
+	out, err := hgCmd.Output()
+	if err != nil {
+		return "", err
+	}
+
+	mercurialBranch := strings.TrimSpace(string(out))
+
+	return mercurialBranch, nil
+}

--- a/pull.go
+++ b/pull.go
@@ -20,7 +20,8 @@ const (
 
 type PullCommand struct {
 	phraseapp.Config
-	Branch string `cli:"opt --branch"`
+	Branch             string `cli:"opt --branch"`
+	UseLocalBranchName bool   `cli:"opt --use-local-branch-name desc='pull from the branch with the name of your currently checked out branch (git or mercurial)'"`
 }
 
 func (cmd *PullCommand) Run() error {
@@ -38,6 +39,12 @@ func (cmd *PullCommand) Run() error {
 	if err != nil {
 		return err
 	}
+
+	branchName, err := usedBranchName(cmd.UseLocalBranchName, cmd.Branch)
+	if err != nil {
+		return err
+	}
+	cmd.Branch = branchName
 
 	projectIdToLocales, err := LocalesForProjects(client, targets, cmd.Branch)
 	if err != nil {

--- a/push.go
+++ b/push.go
@@ -80,7 +80,7 @@ func (cmd *PushCommand) Run() error {
 					printCreateBranchQuestion(cmd.Branch)
 					text, _ := bufio.NewReader(os.Stdin).ReadString('\n')
 
-					if strings.Contains(text, "n") || strings.Contains(text, "N") {
+					if !isYes(strings.TrimSpace(text)) {
 						return nil
 					}
 				}
@@ -414,4 +414,12 @@ func printCreateBranchQuestion(branch string) {
 	ct.ResetColor()
 	fmt.Printf("'.\nThere currently is no branch in PhraseApp with this name.\n\n")
 	fmt.Printf("Should we create a new branch in PhraseApp with the same name and push to it? [y/N]: ")
+}
+
+func isYes(text string) bool {
+	return text == "y" ||
+		text == "Y" ||
+		text == "yes" ||
+		text == "Yes" ||
+		text == "YES"
 }

--- a/push.go
+++ b/push.go
@@ -1,12 +1,14 @@
 package main
 
 import (
+	"bufio"
 	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 	"time"
 
+	ct "github.com/daviddengcn/go-colortext"
 	"github.com/jpillora/backoff"
 	"github.com/phrase/phraseapp-client/internal/paths"
 	"github.com/phrase/phraseapp-client/internal/placeholders"
@@ -17,8 +19,9 @@ import (
 
 type PushCommand struct {
 	phraseapp.Config
-	Wait   bool   `cli:"opt --wait desc='Wait for files to be processed'"`
-	Branch string `cli:"opt --branch"`
+	Wait               bool   `cli:"opt --wait desc='Wait for files to be processed'"`
+	Branch             string `cli:"opt --branch"`
+	UseLocalBranchName bool   `cli:"opt --use-local-branch-name desc='push from the branch with the name of your currently checked out branch (git or mercurial)'"`
 }
 
 func (cmd *PushCommand) Run() error {
@@ -63,12 +66,27 @@ func (cmd *PushCommand) Run() error {
 		projectsAffected[source.ProjectID] = true
 	}
 
+	branchName, err := usedBranchName(cmd.UseLocalBranchName, cmd.Branch)
+	if err != nil {
+		return err
+	}
+	cmd.Branch = branchName
+
 	if cmd.Branch != "" {
 		for projectID := range projectsAffected {
 			_, err := client.BranchShow(projectID, cmd.Branch)
 			if err != nil {
-				branchPrams := &phraseapp.BranchParams{Name: &cmd.Branch}
-				branch, _ := client.BranchCreate(projectID, branchPrams)
+				if useLocalBranchName(cmd.UseLocalBranchName) {
+					printCreateBranchQuestion(cmd.Branch)
+					text, _ := bufio.NewReader(os.Stdin).ReadString('\n')
+
+					if strings.Contains(text, "n") || strings.Contains(text, "N") {
+						return nil
+					}
+				}
+
+				branchParams := &phraseapp.BranchParams{Name: &cmd.Branch}
+				branch, _ := client.BranchCreate(projectID, branchParams)
 
 				fmt.Println()
 
@@ -114,6 +132,7 @@ func (cmd *PushCommand) Run() error {
 			return err
 		}
 	}
+
 	return nil
 }
 
@@ -386,4 +405,13 @@ func getBranchCreateResult(client *phraseapp.Client, projectID string, branch *p
 	}
 
 	return
+}
+
+func printCreateBranchQuestion(branch string) {
+	fmt.Printf("\nYou have currently checked out the branch '")
+	ct.ChangeColor(ct.Green, false, ct.None, false)
+	fmt.Printf("%s", branch)
+	ct.ResetColor()
+	fmt.Printf("'.\nThere currently is no branch in PhraseApp with this name.\n\n")
+	fmt.Printf("Should we create a new branch in PhraseApp with the same name and push to it? [y/N]: ")
 }


### PR DESCRIPTION
This adds an option `--use-local-branch-name` to push/pull to the currently checked out git/mercurial branch. There are also environment variables to set this.