### PR TITLE
Auto extract library revision again

### DIFF
--- a/build/config.sh
+++ b/build/config.sh
@@ -6,7 +6,7 @@ export BUILD_DIR=$(realpath $(dirname $0)/..)
 pushd $BUILD_DIR > /dev/null
 export GOVERSION=${GOVERSION:-1.11}
 export REVISION=${GIT_COMMIT:-$(git rev-parse HEAD)}
-export LIBRARY_REVISION="3f4dacd4d38a89e715d8c5f52f7cfbf776728a2f"
+export LIBRARY_REVISION=$(cat Gopkg.lock | grep github.com/phrase/phraseapp-go -A 2 | tail -n 1 | cut -d '"' -f 2)
 export VERSION=$(cat ${wd}/.version)
 export SOURCE_DATE_EPOCH=$(git log -1 --format=%ct)
 export LAST_CHANGE=$(git log -1 --format=%cd)


### PR DESCRIPTION
Extracting the library revision from Gopkg.lock was broken. As a fix I hardcoded the revision. Now it works again with the latest Gopkg.lock file